### PR TITLE
lsコマンドの作成

### DIFF
--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -23,14 +23,14 @@ class LsCommand
 
   def list_to_show(files)
     # 列の数を指定する。
-    columuns = 3
-    max_rows = if (files.size % columuns).zero?
-                 files.size / columuns
+    column = 3
+    max_rows = if (files.size % column).zero?
+                 files.size / column
                else
-                 (files.size / columuns) + 1
+                 (files.size / column) + 1
                end
 
-    Array.new(columuns) do |i|
+    Array.new(column) do |i|
       if i.zero?
         files.slice(0, max_rows)
       else

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -14,7 +14,7 @@ class LsCommand
 
   def make_list
     Dir.foreach(@current_directory) do |item|
-      next if item.include?('.') || item.include?('..')
+      next if item.start_with?('.') || item.start_with?('..')
 
       @files.push(item)
     end

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -7,6 +7,7 @@ class LsCommand
   def run
     files = get_list
     screen_list = list_to_show(files)
+    screen_in_the_directory(screen_list)
   end
 
   def get_list
@@ -35,7 +36,22 @@ class LsCommand
     end
   end
 
+  def screen_in_the_directory(list)
+    # 一番長い文字列のsizeを取得
+    max_file_name_len = 1
+    @files.each do |file|
+      if file.size >= max_file_name_len
+        max_file_name_len = file.size
+      end
     end
+
+    output_files_list = (0..list[0].size).map do |i|
+      output_file = list.map do |file_array|
+        file_array[i]&.ljust(max_file_name_len + 3)
+      end
+      output_file.join
+    end
+    puts output_files_list
   end
 
 end

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -1,25 +1,43 @@
 class LsCommand
   def initialize()
-      @current_directory = Dir.getwd
+    @current_directory = Dir.getwd
+    @files = Array.new
   end
   
-  def self.run
-    ls = new
-    ls.check_current_directory
+  def run
+    files = get_list
+    screen_list = list_to_show(files)
   end
 
-  def check_current_directory
-    puts @current_directory
-    screen_in_the_directory
-  end
-
-  def screen_in_the_directory
+  def get_list
     Dir.foreach(@current_directory) do |item|
       next if item == '.' or item == '..'
-      puts item
+      @files.push(item)
+    end
+    @files.sort!
+  end
+
+  def list_to_show(files)
+    # 列の数を指定する。
+    columuns = 3
+    max_rows = if files.size % columuns == 0
+      files.size / columuns
+    else
+        (files.size / columuns) + 1
+    end
+
+    split_files = columuns.times.map do |i|
+      if i.zero?
+        files.slice(0, max_rows)
+      else
+        files.slice((max_rows) * i,max_rows)
+      end
+    end
+  end
+
     end
   end
 
 end
 
-LsCommand.run
+LsCommand.new.run

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -9,7 +9,7 @@ class LsCommand
   def run
     files = make_list
     screen_list = list_to_show(files)
-    screen_in_the_directory(screen_list)
+    screen_in_the_directory(screen_list, files)
   end
 
   def make_list
@@ -23,29 +23,45 @@ class LsCommand
   end
 
   def list_to_show(files)
-    # 列の数を指定する。
-    max_rows, mod = files.size.divmod(COLUMN)
-    max_rows += 1 unless mod.zero?
-
+    max_rows = max_rows(files)
     Array.new(COLUMN) do |i|
       files.slice(max_rows * i, max_rows)
     end
   end
 
-  def screen_in_the_directory(list)
+  def screen_in_the_directory(list, files)
     # 一番長い文字列のsizeを取得
-    max_file_name_len = 1
-    list.each do |files|
-      max_file_name_len = files.max_by(&:size).size if files.max_by(&:size).size >= max_file_name_len
-    end
-    output_files_list = (0..list[0].size).map do |i|
-      output_file = list.map do |file_array|
-        file_array[i]&.ljust(max_file_name_len + 3)
-      end
-      output_file.join
+    spacing_between_files = spacing_between_files(list)
+    max_rows = max_rows(files)
+    # 配列の長さを揃えて、transposeする
+    align_list_length = list.each do |item|
+      item.size < max_rows ? item.push(nil) : item
+    end.transpose
+    # 空白を追加してjoinする
+    output_files_list = align_list_length.map do |array|
+      array.map do |file1|
+        file1&.ljust(spacing_between_files)
+      end.join
     end
     puts output_files_list
   end
+
+  def max_rows(files)
+    # 列の数を指定する
+    max_rows, mod = files.size.divmod(COLUMN)
+    max_rows += 1 unless mod.zero?
+    max_rows
+  end
+
+  def spacing_between_files(list)
+    # 出力したファイル名の間隔を決定する
+    spacing_between_files = 1
+    list.each do |item|
+      spacing_between_files = item.max_by(&:size).size + 3 if item.max_by(&:size).size >= max_file_name_len
+    end
+    spacing_between_files
+  end
+
 end
 
 LsCommand.new.run

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class LsCommand
+  COLUMN = 3
   def initialize
     @current_directory = Dir.getwd
   end
@@ -23,14 +24,13 @@ class LsCommand
 
   def list_to_show(files)
     # 列の数を指定する。
-    column = 3
-    max_rows = if (files.size % column).zero?
-                 files.size / column
+    max_rows = if (files.size % COLUMN).zero?
+                 files.size / COLUMN
                else
-                 (files.size / column) + 1
+                 (files.size / COLUMN) + 1
                end
 
-    Array.new(column) do |i|
+    Array.new(COLUMN) do |i|
       if i.zero?
         files.slice(0, max_rows)
       else

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -39,11 +39,8 @@ class LsCommand
     # 一番長い文字列のsizeを取得
     max_file_name_len = 1
     list.each do |files|
-      files.each do |file|
-        max_file_name_len = file.size if file.size >= max_file_name_len
-      end
+      max_file_name_len = files.max_by(&:size).size if files.max_by(&:size).size >= max_file_name_len
     end
-
     output_files_list = (0..list[0].size).map do |i|
       output_file = list.map do |file_array|
         file_array[i]&.ljust(max_file_name_len + 3)

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -1,0 +1,17 @@
+class LsCommand
+  def initialize()
+      @current_directory = Dir.getwd
+  end
+  
+  def self.run
+    ls = new
+    ls.check_current_directory
+  end
+
+  def check_current_directory
+    puts @current_directory
+  end
+
+end
+
+LsCommand.run

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -3,7 +3,6 @@
 class LsCommand
   def initialize
     @current_directory = Dir.getwd
-    @files = []
   end
 
   def run
@@ -13,12 +12,13 @@ class LsCommand
   end
 
   def make_list
+    files = []
     Dir.foreach(@current_directory) do |item|
-      next if item.start_with?('.') || item.start_with?('..')
+      next if item.start_with?('.', '..')
 
-      @files.push(item)
+      files.push(item)
     end
-    @files.sort
+    files.sort
   end
 
   def list_to_show(files)
@@ -42,8 +42,10 @@ class LsCommand
   def screen_in_the_directory(list)
     # 一番長い文字列のsizeを取得
     max_file_name_len = 1
-    @files.each do |file|
-      max_file_name_len = file.size if file.size >= max_file_name_len
+    list.each do |files|
+      files.each do |file|
+        max_file_name_len = file.size if file.size >= max_file_name_len
+      end
     end
 
     output_files_list = (0..list[0].size).map do |i|

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -24,11 +24,8 @@ class LsCommand
 
   def list_to_show(files)
     # 列の数を指定する。
-    max_rows = if (files.size % COLUMN).zero?
-                 files.size / COLUMN
-               else
-                 (files.size / COLUMN) + 1
-               end
+    max_rows, mod = files.size.divmod(COLUMN)
+    max_rows += 1 if mod.zero?
 
     Array.new(COLUMN) do |i|
       files.slice(max_rows * i, max_rows)

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -10,6 +10,14 @@ class LsCommand
 
   def check_current_directory
     puts @current_directory
+    screen_in_the_directory
+  end
+
+  def screen_in_the_directory
+    Dir.foreach(@current_directory) do |item|
+      next if item == '.' or item == '..'
+      puts item
+    end
   end
 
 end

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -25,7 +25,7 @@ class LsCommand
   def list_to_show(files)
     # 列の数を指定する。
     max_rows, mod = files.size.divmod(COLUMN)
-    max_rows += 1 if mod.zero?
+    max_rows += 1 unless mod.zero?
 
     Array.new(COLUMN) do |i|
       files.slice(max_rows * i, max_rows)

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -31,11 +31,7 @@ class LsCommand
                end
 
     Array.new(COLUMN) do |i|
-      if i.zero?
-        files.slice(0, max_rows)
-      else
-        files.slice(max_rows * i, max_rows)
-      end
+      files.slice(max_rows * i, max_rows)
     end
   end
 

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -34,9 +34,8 @@ class LsCommand
     spacing_between_files = spacing_between_files(list)
     max_rows = max_rows(files)
     # 配列の長さを揃えて、transposeする
-    align_list_length = list.each do |item|
-      item.size < max_rows ? item.push(nil) : item
-    end.transpose
+    align_list_length = list.map {
+      |item| item + [nil] * (max_rows - item.length) }.transpose
     # 空白を追加してjoinする
     output_files_list = align_list_length.map do |array|
       array.map do |file1|
@@ -55,11 +54,7 @@ class LsCommand
 
   def spacing_between_files(list)
     # 出力したファイル名の間隔を決定する
-    spacing_between_files = 1
-    list.each do |item|
-      spacing_between_files = item.max_by(&:size).size + 3 if item.max_by(&:size).size >= max_file_name_len
-    end
-    spacing_between_files
+    (list.flatten.map(&:size) + [1]).max + 3
   end
 
 end

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -1,37 +1,40 @@
+# frozen_string_literal: true
+
 class LsCommand
-  def initialize()
+  def initialize
     @current_directory = Dir.getwd
-    @files = Array.new
+    @files = []
   end
-  
+
   def run
-    files = get_list
+    files = make_list
     screen_list = list_to_show(files)
     screen_in_the_directory(screen_list)
   end
 
-  def get_list
+  def make_list
     Dir.foreach(@current_directory) do |item|
-      next if item == '.' or item == '..'
+      next if item.include?('.') || item.include?('..')
+
       @files.push(item)
     end
-    @files.sort!
+    @files.sort
   end
 
   def list_to_show(files)
     # 列の数を指定する。
     columuns = 3
-    max_rows = if files.size % columuns == 0
-      files.size / columuns
-    else
-        (files.size / columuns) + 1
-    end
+    max_rows = if (files.size % columuns).zero?
+                 files.size / columuns
+               else
+                 (files.size / columuns) + 1
+               end
 
-    split_files = columuns.times.map do |i|
+    Array.new(columuns) do |i|
       if i.zero?
         files.slice(0, max_rows)
       else
-        files.slice((max_rows) * i,max_rows)
+        files.slice(max_rows * i, max_rows)
       end
     end
   end
@@ -40,9 +43,7 @@ class LsCommand
     # 一番長い文字列のsizeを取得
     max_file_name_len = 1
     @files.each do |file|
-      if file.size >= max_file_name_len
-        max_file_name_len = file.size
-      end
+      max_file_name_len = file.size if file.size >= max_file_name_len
     end
 
     output_files_list = (0..list[0].size).map do |i|
@@ -53,7 +54,6 @@ class LsCommand
     end
     puts output_files_list
   end
-
 end
 
 LsCommand.new.run


### PR DESCRIPTION
# lsコマンド仕様（オプション、引数なし）
## 機能
カレントディレクトリ内にあるディレクトリ、ファイルを一覧表示する。
### 標準出力内容
横に最大3列を維持して表示する。
list_to_showメソッド内のcolumnの値で変更可能。
## 動作
* カレントディレクトリのフルパス取得
* フルパスで指定したディレクトリの中のディレクトリとファイル名を配列で取得
* 行の数の分だけ要素をもった配列を列の数作成
* 表示形式に則した形に整形
* 表示する
＊ディレクトリが空だった場合には何も出力しない

