### PR TITLE
lsコマンド　-aオプションを追加

### DIFF
--- a/04.ls/.gitignore
+++ b/04.ls/.gitignore
@@ -1,0 +1,1 @@
+lib/dummy/

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -8,20 +8,17 @@ class LsCommand
 
   def run
     case ARGV.join
-      when /^-.*[a-zA-Z]/
-      files = make_list
-      screen_list = list_to_show(files)
-      screen_in_the_directory(screen_list, files)
-      when ""
-      files = make_list
-      screen_list = list_to_show(files)
-      screen_in_the_directory(screen_list, files)
+      when /^-.*[a-zA-Z]/,""
+        option = ARGV.join
+        files = make_list(option)
+        screen_list = list_to_show(files)
+        screen_in_the_directory(screen_list, files)
       else
         p "無効なオプションです"
     end
   end
 
-  def make_list
+  def make_list(option)
     files = []
     Dir.foreach(@current_directory) do |item|
       if !option.include?('a')

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'optparse'
+
 class LsCommand
   COLUMN = 3
   def initialize
@@ -7,23 +9,20 @@ class LsCommand
   end
 
   def run
-    case ARGV.join
-      when /^-.*[a-zA-Z]/,""
-        option = ARGV.join
-        files = make_list(option)
-        screen_list = list_to_show(files)
-        screen_in_the_directory(screen_list, files)
-      else
-        p "無効なオプションです"
-    end
+    opt = OptionParser.new
+    option = {}
+    opt.on('-a') { |a| a }
+    opt.parse(ARGV, into: option)
+    files = make_list(option)
+    screen_list = list_to_show(files)
+    screen_in_the_directory(screen_list, files)
   end
 
   def make_list(option)
     files = []
     Dir.foreach(@current_directory) do |item|
-      if !option.include?('a')
-      next if item.start_with?('.', '..')
-      end
+      next if !option[:a] == true && item.start_with?('.', '..')
+
       files.push(item)
     end
     files.sort
@@ -41,8 +40,7 @@ class LsCommand
     spacing_between_files = spacing_between_files(list)
     max_rows = max_rows(files)
     # 配列の長さを揃えて、transposeする
-    align_list_length = list.map {
-      |item| item + [nil] * (max_rows - item.length) }.transpose
+    align_list_length = list.map { |item| item + [nil] * (max_rows - item.length) }.transpose
     # 空白を追加してjoinする
     output_files_list = align_list_length.map do |array|
       array.map do |file1|
@@ -63,7 +61,6 @@ class LsCommand
     # 出力したファイル名の間隔を決定する
     (list.flatten.map(&:size) + [1]).max + 3
   end
-
 end
 
 LsCommand.new.run

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -7,16 +7,26 @@ class LsCommand
   end
 
   def run
-    files = make_list
-    screen_list = list_to_show(files)
-    screen_in_the_directory(screen_list, files)
+    case ARGV.join
+      when /^-.*[a-zA-Z]/
+      files = make_list
+      screen_list = list_to_show(files)
+      screen_in_the_directory(screen_list, files)
+      when ""
+      files = make_list
+      screen_list = list_to_show(files)
+      screen_in_the_directory(screen_list, files)
+      else
+        p "無効なオプションです"
+    end
   end
 
   def make_list
     files = []
     Dir.foreach(@current_directory) do |item|
+      if !option.include?('a')
       next if item.start_with?('.', '..')
-
+      end
       files.push(item)
     end
     files.sort

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -30,7 +30,8 @@ class LsCommand
 
   def list_to_show(files)
     max_rows = max_rows(files)
-    Array.new(COLUMN) do |i|
+    run_count = files.size <= COLUMN ? files.size : COLUMN # nilが入るのを防ぐために実行回数を制限
+    Array.new(run_count) do |i|
       files.slice(max_rows * i, max_rows)
     end
   end

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -30,8 +30,8 @@ class LsCommand
 
   def list_to_show(files)
     max_rows = max_rows(files)
-    run_count = files.size <= COLUMN ? files.size : COLUMN # nilが入るのを防ぐために実行回数を制限
-    Array.new(run_count) do |i|
+    list_length = [files.size, COLUMN].min
+    Array.new(list_length) do |i|
       files.slice(max_rows * i, max_rows)
     end
   end

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -11,7 +11,7 @@ class LsCommand
   def run
     opt = OptionParser.new
     option = {}
-    opt.on('-a') { |a| a }
+    opt.on('-a')
     opt.parse(ARGV, into: option)
     files = make_list(option)
     screen_list = list_to_show(files)

--- a/04.ls/lib/ls_command.rb
+++ b/04.ls/lib/ls_command.rb
@@ -21,7 +21,7 @@ class LsCommand
   def make_list(option)
     files = []
     Dir.foreach(@current_directory) do |item|
-      next if !option[:a] == true && item.start_with?('.', '..')
+      next if !option[:a] && item.start_with?('.', '..')
 
       files.push(item)
     end


### PR DESCRIPTION
コマンドラインのオプションを引数として受け取り、
かならず「-」から始まる半角英文字のみ受け取るようにしました。